### PR TITLE
fix: dacite value not found

### DIFF
--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -23,6 +23,7 @@ import select
 import json
 import threading
 from socket import SOCK_DGRAM, SOCK_STREAM
+from typing import Optional
 from dacite.core import from_dict
 from iperf3.iperf3_interfaces import IperfResult
 
@@ -672,10 +673,15 @@ class Client(IPerf3):
         result = self.run()
         return TestResult(result)
 
-    def run_json(self) -> IperfResult:
+    def run_json(self) -> Optional[IperfResult]:
         result = self.run()
         self.json = json.loads(result)
-        return from_dict(data_class=IperfResult, data=self.json)
+        try:
+            data = from_dict(data_class=IperfResult, data=self.json)
+            return data
+        except KeyError as ke:
+            print(f"Warning: {ke}. Returning None")
+            return None
 
 
 class Server(IPerf3):
@@ -752,10 +758,15 @@ class Server(IPerf3):
         result = self.run()
         return TestResult(result)
 
-    def run_json(self) -> IperfResult:
+    def run_json(self) -> Optional[IperfResult]:
         result = self.run()
         self.json = json.loads(result)
-        return from_dict(data_class=IperfResult, data=self.json)
+        try:
+            data = from_dict(data_class=IperfResult, data=self.json)
+            return data
+        except KeyError as ke:
+            print(f"Warning: {ke}. Returning None")
+            return None
 
 
 class TestResult:

--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -679,8 +679,8 @@ class Client(IPerf3):
         try:
             data = from_dict(data_class=IperfResult, data=self.json)
             return data
-        except KeyError as ke:
-            print(f"Warning: {ke}. Returning None")
+        except:
+            print(f"Warning - Returning None")
             return None
 
 
@@ -764,8 +764,8 @@ class Server(IPerf3):
         try:
             data = from_dict(data_class=IperfResult, data=self.json)
             return data
-        except KeyError as ke:
-            print(f"Warning: {ke}. Returning None")
+        except:
+            print(f"Warning - Returning None")
             return None
 
 

--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -24,7 +24,9 @@ import json
 import threading
 from socket import SOCK_DGRAM, SOCK_STREAM
 from typing import Optional
+import warnings
 from dacite.core import from_dict
+from dacite.exceptions import MissingValueError
 from iperf3.iperf3_interfaces import IperfResult
 
 try:
@@ -679,8 +681,8 @@ class Client(IPerf3):
         try:
             data = from_dict(data_class=IperfResult, data=self.json)
             return data
-        except:
-            print(f"Warning - Returning None")
+        except MissingValueError as e:
+            warnings.warn(f"{e}. Returning result as 'None'")
             return None
 
 
@@ -764,8 +766,8 @@ class Server(IPerf3):
         try:
             data = from_dict(data_class=IperfResult, data=self.json)
             return data
-        except:
-            print(f"Warning - Returning None")
+        except MissingValueError as e:
+            warnings.warn(f"{e}. Returning result as 'None'")
             return None
 
 


### PR DESCRIPTION
- Fix case when the client is called and the server is not running. Dacite will throw an error, but this can be caught and returned as None to represent no data present.